### PR TITLE
Got tests working on Debian by changing shebang line

### DIFF
--- a/test
+++ b/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Usage: 'test <command> ...' to test a specific implementation, or
 # 'test <name>' as a shortcut to test a specific implementation or all

--- a/torture-test
+++ b/torture-test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Usage: 'torture-test <command> ...' to test a specific implementation.
 #


### PR DESCRIPTION
Thanks this is awesome!   I love code comparisons, and this gives me an excuse to learn a little Rust.  I'll have some more thoughts  later

---

About this change:

`/bin/sh` is Dash on most Linux machines, and dash doesn't have `${a:0}` for indexing, or `<(echo process sub)`


If this breaks your workflow, it's not crucial.  (e.g. maybe you're running with zsh)

```
$ ./torture-test original/nfa
PASSED
```

```
$ ./test all
=== original ===
//badsyntax ... FAILED
a|/a/badsyntax ... FAILED
a.b/a.b/badsyntax ... FAILED
=== dumb-translation(rust) ===
=== safe-translation(rust) ===
=== idiomatic-translation(rust) ===
=== regex crate ===

```
